### PR TITLE
feat: implement repository interfaces and update service to use it

### DIFF
--- a/Dockerfile-ubi9
+++ b/Dockerfile-ubi9
@@ -1,0 +1,43 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.6
+ENV container=docker
+ENV LANG=C.UTF-8
+ENV TZ=/usr/share/zoneinfo/Asia/Bangkok
+
+# Set working directory
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+# Install system dependencies
+RUN /usr/bin/yum install -y  python3.12 python3.12-pip python3.12-cryptography python3.12-cffi python3.12-idna python3.12-ply python3.12-pycparser python3.12-pyyaml python3.12-setuptools-wheel python3.12-setuptools python3.12-packaging ; \
+yum clean all ; \
+pip3.12 install "fastapi[standard]" gunicorn pyjwt
+
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip3.12 install --no-cache-dir -r requirements.txt
+
+# Copy application code
+#COPY app.py .
+COPY app /app/
+
+# Create non-root user for security
+RUN useradd appuser -m -s /bin/bash \
+    && chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+# Run the application
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"] 

--- a/app/app.py
+++ b/app/app.py
@@ -192,7 +192,7 @@ async def upload_file(file: UploadFile = File(...), payload: dict = Depends(veri
         file_content = await file.read()
         
         # Upload to GCS
-        result = file_upload_svc.upload_file(file_content, file.filename, file.content_type)
+        result = file_upload_svc.upload_file(file_content, file.filename, file.content_type) # type: ignore
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}")

--- a/app/repository/bigquery_league_repo.py
+++ b/app/repository/bigquery_league_repo.py
@@ -4,8 +4,9 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 from google.cloud import bigquery
 from model.league import LeagueRequest, LeagueResponse
+from repository.league_repo_interface import ILeagueRepository
 
-class LeagueRepository():
+class LeagueRepository(ILeagueRepository):
     def __init__(self, client: bigquery.Client, project_id: str, dataset_name: str, table_name: str):
         self.client = client
         self.project_id = project_id

--- a/app/repository/bigquery_match_repo.py
+++ b/app/repository/bigquery_match_repo.py
@@ -2,6 +2,7 @@ from typing import Optional, List
 from fastapi import HTTPException, status
 from google.cloud import bigquery
 from model.match import MatchRequest, MatchResponse
+from repository.match_repo_interface import IMatchRepository
 
 """
 CREATE TABLE user.matches (
@@ -15,7 +16,7 @@ CREATE TABLE user.matches (
 )
 """
 
-class MatchRepository:
+class MatchRepository(IMatchRepository):
     def __init__(self, client: bigquery.Client, project_id: str, dataset_name: str, table_name: str, league_table_name: str):
         self.client = client
         self.project_id = project_id

--- a/app/repository/bigquery_url_submission_repo.py
+++ b/app/repository/bigquery_url_submission_repo.py
@@ -236,4 +236,4 @@ class UrlSubmissionRepository:
         query_job.result()  # Wait for the query to complete
         
         # Check if any rows were affected
-        return query_job.num_dml_affected_rows > 0 
+        return query_job.num_dml_affected_rows is not None and query_job.num_dml_affected_rows > 0 

--- a/app/repository/bigquery_url_submission_repo.py
+++ b/app/repository/bigquery_url_submission_repo.py
@@ -1,9 +1,10 @@
+from typing import List, Optional
+import uuid
 from google.cloud import bigquery
 from datetime import datetime, timezone
-import uuid
-from typing import List, Optional
+from repository.url_submission_repo_interface import IUrlSubmissionRepository
 
-class UrlSubmissionRepository:
+class UrlSubmissionRepository(IUrlSubmissionRepository):
     def __init__(self, client: bigquery.Client, project_id: str, dataset_name: str, table_name: str = "url_submission"):
         self.client = client
         self.project_id = project_id

--- a/app/repository/bigquery_user_repo.py
+++ b/app/repository/bigquery_user_repo.py
@@ -2,7 +2,9 @@ from typing import Optional
 from fastapi import HTTPException, status
 from google.cloud import bigquery
 
-class UserRepository:
+from repository.user_repo_interface import IUserRepository
+
+class UserRepository(IUserRepository):
     def __init__(self, client: bigquery.Client, project_id: str, dataset_name: str, table_name: str):
         self.client = client
         self.project_id = project_id

--- a/app/repository/file_repo_interface.py
+++ b/app/repository/file_repo_interface.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+class IGCSFileRepository(ABC):
+    @abstractmethod
+    def upload_file(self, file_content: bytes, file_name: str, content_type: str) -> dict:
+        pass
+
+    @abstractmethod
+    def delete_file(self, file_name: str) -> bool:
+        pass
+    
+    @abstractmethod
+    def get_file_url(self, file_name: str) -> Optional[str]:
+        pass

--- a/app/repository/gcs_file_repo.py
+++ b/app/repository/gcs_file_repo.py
@@ -3,8 +3,9 @@ from datetime import datetime, timezone, timedelta
 import uuid
 import os
 from typing import Optional
+from repository.file_repo_interface import IGCSFileRepository
 
-class GCSFileRepository:
+class GCSFileRepository(IGCSFileRepository):
     def __init__(self, bucket_name: str = "web_anti", project_id: str = "practise-bi", service_account_path: Optional[str] = None):
         self.bucket_name = bucket_name
         self.project_id = project_id

--- a/app/repository/league_repo_interface.py
+++ b/app/repository/league_repo_interface.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from model.league import LeagueRequest, LeagueResponse
+
+class ILeagueRepository(ABC):
+    @abstractmethod
+    def add(self, league_data: LeagueRequest) -> LeagueResponse:
+        pass
+
+    @abstractmethod
+    def list(self) -> List[LeagueResponse]:
+        pass
+
+    @abstractmethod
+    def delete(self, league_id: str) -> int:
+        pass
+
+    @abstractmethod
+    def get(self, league_id: str) -> Optional[LeagueResponse]:
+        pass
+
+    @abstractmethod
+    def update(self, league_id: str, leage_info: LeagueRequest) -> Optional[LeagueResponse]:
+        pass

--- a/app/repository/match_repo_interface.py
+++ b/app/repository/match_repo_interface.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from model.match import MatchRequest, MatchResponse
+
+class IMatchRepository(ABC):
+    @abstractmethod
+    def list_all(self) -> List[MatchResponse]:
+        pass
+
+    @abstractmethod
+    def add(self, match_data: MatchRequest) -> int:
+        pass
+
+    @abstractmethod
+    def get(self, match_id: int) -> Optional[MatchResponse]:
+        pass
+    
+    @abstractmethod
+    def delete(self, match_id: int) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def update(self, match_id: int, match_info: MatchRequest) -> int:
+        pass

--- a/app/repository/url_submission_repo_interface.py
+++ b/app/repository/url_submission_repo_interface.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+class IUrlSubmissionRepository(ABC):
+    @abstractmethod
+    def add_url_submission(self, url: str, type: Optional[str] = None, league_id: Optional[str] = None, 
+                          match_id: Optional[str] = None, status: Optional[str] = None, 
+                          image_file_name: Optional[str] = None) -> dict:
+        pass
+
+    @abstractmethod
+    def get_url_submission_by_id(self, submission_id: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    def list_all_url_submissions(self) -> List[dict]:
+        pass
+
+    @abstractmethod
+    def update_url_submission(self, submission_id: str, url: Optional[str] = None, type: Optional[str] = None,
+                             league_id: Optional[str] = None, match_id: Optional[str] = None,
+                             status: Optional[str] = None, image_file_name: Optional[str] = None) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    def delete_url_submission(self, submission_id: str) -> bool:
+        pass

--- a/app/repository/url_submission_repo_interface.py
+++ b/app/repository/url_submission_repo_interface.py
@@ -23,5 +23,10 @@ class IUrlSubmissionRepository(ABC):
         pass
 
     @abstractmethod
+    def check_url_exists_in_match(self, url: str, match_id: str) -> bool:
+        """Check if a URL already exists for a given match_id"""
+        pass
+
+    @abstractmethod
     def delete_url_submission(self, submission_id: str) -> bool:
         pass

--- a/app/repository/user_repo_interface.py
+++ b/app/repository/user_repo_interface.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+from model.user import User
+
+class IUserRepository(ABC):
+    @abstractmethod
+    def get_user_by_username(self, username: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    def update_last_login(self, user_id: str):
+        pass

--- a/app/service/file_upload_svc.py
+++ b/app/service/file_upload_svc.py
@@ -1,8 +1,8 @@
-from repository.gcs_file_repo import GCSFileRepository
+from repository.file_repo_interface import IGCSFileRepository
 from model.file_upload import FileUploadResponse
 
 class FileUploadSvc:
-    def __init__(self, gcs_file_repo: GCSFileRepository):
+    def __init__(self, gcs_file_repo: IGCSFileRepository):
         self.gcs_file_repo = gcs_file_repo
 
     def upload_file(self, file_content: bytes, file_name: str, content_type: str) -> FileUploadResponse:

--- a/app/service/league_svc.py
+++ b/app/service/league_svc.py
@@ -1,9 +1,10 @@
 from typing import List, Optional
 from fastapi import HTTPException, status
 from model.league import LeagueRequest, LeagueResponse
-from repository.bigquery_league_repo import LeagueRepository
+from repository.league_repo_interface import ILeagueRepository
+
 class LeagueSvc():
-    def __init__(self, league_repo: LeagueRepository):
+    def __init__(self, league_repo: ILeagueRepository):
         self.league_repo = league_repo
     
     def add_league_to_database(self, league_data: LeagueRequest) -> LeagueResponse:

--- a/app/service/login_svc.py
+++ b/app/service/login_svc.py
@@ -3,10 +3,10 @@ from datetime import timedelta
 from fastapi import HTTPException, status
 from core.security import create_access_token
 from model.login import LoginResponse
-from repository.bigquery_user_repo import UserRepository
+from repository.user_repo_interface import IUserRepository
 
 class LoginSvc:
-    def __init__(self, user_repo: UserRepository):
+    def __init__(self, user_repo: IUserRepository):
         self.user_repo = user_repo
     
     def do_login(self, username: str, password: str, session_ttl_hours: int):

--- a/app/service/match_svc.py
+++ b/app/service/match_svc.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 from fastapi import HTTPException, status
 from model.match import MatchRequest, MatchResponse
-from repository.bigquery_match_repo import MatchRepository
+from repository.match_repo_interface import IMatchRepository
 
 class MatchSvc():
-    def __init__(self, match_repo: MatchRepository):
+    def __init__(self, match_repo: IMatchRepository):
         self.match_repo = match_repo
 
     def add_match(self, match_data: MatchRequest) -> Optional[dict]:

--- a/app/service/url_submission_svc.py
+++ b/app/service/url_submission_svc.py
@@ -1,9 +1,9 @@
-from repository.bigquery_url_submission_repo import UrlSubmissionRepository
+from repository.url_submission_repo_interface import IUrlSubmissionRepository
 from model.url_submission import UrlSubmissionRequest
 from typing import List, Optional
 
 class UrlSubmissionSvc:
-    def __init__(self, url_submission_repo: UrlSubmissionRepository):
+    def __init__(self, url_submission_repo: IUrlSubmissionRepository):
         self.url_submission_repo = url_submission_repo
 
     def add_url_submission(self, url_submission_request: UrlSubmissionRequest) -> dict:

--- a/app/service/user_svc.py
+++ b/app/service/user_svc.py
@@ -1,9 +1,9 @@
 from fastapi import HTTPException, status
 from model.user import User
-from repository.bigquery_user_repo import UserRepository
+from repository.user_repo_interface import IUserRepository
 
 class UserSvc:
-    def __init__(self, user_repo: UserRepository):
+    def __init__(self, user_repo: IUserRepository):
         self.user_repo = user_repo
 
     def get_user_info(self, username: str):


### PR DESCRIPTION
Add interface between repository and service to decouple business logic from concrete implementations. 
Service layer can be based on an abstract interface, rather than directly relying on a specific database repository or external service.